### PR TITLE
[fix]: Correct typo in Salary model attribute from 'salara_range' to …

### DIFF
--- a/src/domain/position.py
+++ b/src/domain/position.py
@@ -40,7 +40,7 @@ class Languages(BaseModel):
 class Salary(BaseModel):
     currency: str
     salary: str
-    salara_range: str
+    salary_range: str
 
 
 class PositionStakeholders(BaseModel):


### PR DESCRIPTION
…'salary_range'